### PR TITLE
En los emails no se ve la @

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
         </header>
         <ul>
           <li><strong>nickname:</strong> olvap</li>
-          <li><strong>email:</strong> oldani.pablo<at>gmail.com</li>
+          <li><strong>email:</strong> oldani.pablo&commat;gmail.com</li>
           <li><strong>github:</strong> olvap</li>
           <li><strong>linkdin:</strong> oldanipablo</li>
           <li><strong>twitter:</strong> olvap</li>
@@ -158,7 +158,7 @@
         </header>
         <ul>
           <li><strong>nickname:</strong> eloyesp</li>
-          <li><strong>email:</strong> eloyesp<at>gmail.com</li>
+          <li><strong>email:</strong> eloyesp&commat;gmail.com</li>
           <li><strong>github:</strong> eloyesp</li>
           <li><strong>twitter:</strong> eloypes</li>
         </ul>


### PR DESCRIPTION
Primero pensé que tal vez era a propósito para evitar bots de spammers. Luego vi que en el código usaban un tag 'at'...
